### PR TITLE
Removing unused package dependency razor_imu_9dof.

### DIFF
--- a/racecar/racecar/CMakeLists.txt
+++ b/racecar/racecar/CMakeLists.txt
@@ -79,7 +79,6 @@ catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES racecar_launch
   CATKIN_DEPENDS
-    razor_imu_9dof
     tf
     tf2_ros
     urg_node

--- a/racecar/racecar/launch/includes/common/sensors.launch.xml
+++ b/racecar/racecar/launch/includes/common/sensors.launch.xml
@@ -11,7 +11,4 @@
 <!-- Set the port to connect to here -->
   <param name="port" type="string" value="/dev/ttyACM0"/> 
 
-  <!-- imu -->
-  <!--node pkg="razor_imu_9dof" type="imu_node.py" name="imu_node" /-->
-
 </launch>

--- a/racecar/racecar/package.xml
+++ b/racecar/racecar/package.xml
@@ -16,7 +16,6 @@
 
   <!--<build_depend></build_depend>-->
 
-  <run_depend>razor_imu_9dof</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>urg_node</run_depend>


### PR DESCRIPTION
Removes the dependency on the `razor_imu_9dof` package so `rosdep` doesn't choke on it anymore.